### PR TITLE
docs: add UI SFX sound library

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ List of curated UI libraries, templates and inspirations
 | SolaceUI          | Blocks       | React        | -                                                 | <https://www.solaceui.com>           | -                                            | -        | -                                              |
 | Supabase UI       | Mixed        | React        | -                                                 | <https://supabase.com/ui>            | -                                            | -        | -                                              |
 | Tailark           | Blocks       | React        | <https://github.com/tailark/blocks>               | <https://tailark.com>                | [Yes](https://pro.tailark.com)               | -        | -                                              |
+| UI SFX            | Sound        | Multiple     | <https://github.com/romainsimon/uisfx>            | <https://uisfx.com>                  | -                                            | -        | -                                              |
 | visual-effect     | Animation    | React        | <https://github.com/kitlangton/visual-effect>     | <https://effect.kitlangton.com>      | -                                            | -        | -                                              |
 | XD UI             | AI           | React        | <https://github.com/suraj-xd/XD-UI-Library>       | <https://ui.surajgaud.com>           | -                                            | -        | -                                              |
 


### PR DESCRIPTION
## What changed

- Add UI SFX to the Components list as a framework-agnostic sound library.
- Link to both the open-source repository and the interactive website.

## Why

Sound feedback is part of interface design, and the existing Components table already groups specialized UI libraries by kind. Using the existing `Sound` kind keeps this contribution focused without creating a one-item category.

## Validation

- Verified the repository and website links.
- Ran `git diff --check`.
